### PR TITLE
Dev deleting surveys

### DIFF
--- a/src/repositories/survey_repository.py
+++ b/src/repositories/survey_repository.py
@@ -40,6 +40,24 @@ class SurveyRepository:
         self.db_connection.session.commit()
         return survey_id[0]
 
+    def delete_survey(self, survey_id):
+        """ Deletes a survey from Surveys after deleting all
+        questions, results and groups which relate to it.
+        After deletion, checks if survey has been deleted
+        and returns the result """
+        sql = """ DELETE FROM "Questions" WHERE "surveyId"=:id """
+        db.session.execute(sql, {"id": survey_id})
+        sql = """ DELETE FROM "Survey_results" WHERE "surveyId"=:id """
+        db.session.execute(sql, {"id": survey_id})
+        sql = """ DELETE FROM "Survey_user_groups" WHERE "surveyId"=:id """
+        db.session.execute(sql, {"id": survey_id})
+        sql = """ DELETE FROM "Surveys" WHERE "id"=:id """
+        db.session.execute(sql, {"id": survey_id})
+        db.session.commit()
+        if self.get_survey(survey_id) is False:
+            return True
+        return False
+
     def get_survey(self, survey_id):
         """ Looks up survey information with
         id and returns it in a list"""
@@ -88,11 +106,11 @@ class SurveyRepository:
 
         questions = result.fetchall()
 
-        return questions    
+        return questions
 
     def delete_question_from_survey(self, question_id):
         """ Deletes a question in a given survey
-        
+
         Args:
             question_id: Id of the question
 
@@ -106,4 +124,3 @@ class SurveyRepository:
         if not result:
             return False
         return True
-

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -62,6 +62,20 @@ class SurveyService:
 
         return self.survey_repository.get_survey(survey_id)
 
+    def delete_survey(self, survey_id: str):
+        """
+        Deletes survey from the repository
+
+        Args:
+            survey_id: Db id of survey
+
+        Returns:
+            If succeeds: True
+            If not: False
+        """
+
+        return self.survey_repository.delete_survey(survey_id)
+
     def delete_question_from_survey(self, question_id: str):
         """ Removes a question from a survey.
         Args:
@@ -104,7 +118,7 @@ class SurveyService:
         """
         if len(name) < 1 or len(title) < 1 or len(description) < 1:
             raise UserInputError("Missing required information of survey")
-            
+
         if len(name) > 1000 or len(title) > 1000 or len(description) > 1000:
             raise UserInputError("Survey input is too long")
 

--- a/src/templates/surveys/view_survey.html
+++ b/src/templates/surveys/view_survey.html
@@ -24,7 +24,11 @@
 {% else %}
 <p>Survey has no questions 🥺</p>
 {% endif %}
-
+<form action="/delete_survey" method="POST">
+  <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
+  <input type="hidden" name="id" value="{{ survey[0] }}">
+  <button name="delete" value="delete" onclick="return confirm('Are you sure you want to delete this survey?')">Delete Survey</button>
+</form>
 {% else %}
 There is no survey with ID: {{ survey_id }}
 {% endif %}

--- a/src/tests/robot_tests/create_survey.robot
+++ b/src/tests/robot_tests/create_survey.robot
@@ -11,7 +11,6 @@ Test Setup  Go To Home Page
 Logged In User Can Create Surveys
     Go To Backdoor Login Page
     Login With Correct Credentials
-    Make Two Surveys
     Go To Home Page
     Click Link  Create a new survey
     Make A Survey
@@ -51,4 +50,10 @@ Questions Of Survey Are Displayed On Survey Page
 Logged Out User Cannot Create Surveys
     Logout
     Go To Create New Survey Page
+    Page Should Contain  Please login
+
+Logged Out User Cannot See Surveys
+    Go To Survey  1
+    Page Should Contain  Please login
+    Go To Home Page
     Page Should Contain  Please login

--- a/src/tests/robot_tests/delete_survey.robot
+++ b/src/tests/robot_tests/delete_survey.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Resource  resource.robot
+Resource  resource_login.robot
+Resource  resource_delete_survey.robot
+Suite Setup  Open And Configure Browser
+Suite Teardown  Close Browser
+Test Setup  Go To Home Page
+
+*** Test Cases ***
+
+Delete An Existing Survey
+    Go To Backdoor Login Page
+    Login With Correct Credentials
+    Make A Survey To Delete
+    Delete The Survey
+    Page Should Not Contain  Poistuisikohan

--- a/src/tests/robot_tests/resource_create_survey.robot
+++ b/src/tests/robot_tests/resource_create_survey.robot
@@ -14,20 +14,6 @@ Set Survey Text
 Create A Survey
     Click Button  Create Survey
 
-Make Two Surveys
-    Go To Home Page
-    Click Link  Create a new survey
-    Set Survey Name  Making two surveys
-    Set Survey Title  Which fail
-    Set Survey Text  To make the third one work
-    Create A Survey
-    Go To Home Page
-    Click Link  Create a new survey
-    Set Survey Name  Making two surveys
-    Set Survey Title  Which fail
-    Set Survey Text  To make the third one work
-    Create A Survey
-
 Make A Survey
     Set Survey Name  Testi
     Set Survey Title  Surveyn tekeminen testauksessa

--- a/src/tests/robot_tests/resource_delete_survey.robot
+++ b/src/tests/robot_tests/resource_delete_survey.robot
@@ -1,0 +1,27 @@
+*** Keywords ***
+Set Survey Name
+    [Arguments]  ${name}
+    Input Text  name  ${name}
+
+Set Survey Title
+    [Arguments]  ${title}
+    Input Text  title  ${title}
+
+Set Survey Text
+    [Arguments]  ${text}
+    Input Text  survey  ${text}
+
+Create A Survey
+    Click Button  Create Survey
+
+Delete The Survey
+    Click Button  Delete Survey
+    Handle Alert  Accept
+
+Make A Survey To Delete
+    Go To Home Page
+    Click Link  Create a new survey
+    Set Survey Name  Must Not Contain
+    Set Survey Title  Poistuisikohan
+    Set Survey Text  On Home Page
+    Create A Survey

--- a/src/views/surveys.py
+++ b/src/views/surveys.py
@@ -68,6 +68,20 @@ def create_survey():
 
     return redirect(route)
 
+@surveys.route("/delete_survey", methods=["POST"])
+def delete_survey():
+    """ Takes survey id from new.html and calls
+    a db function to delete the survey using the id
+    and redirects to homepage if deletion succeeded,
+    otherwise redirects back to the survey """
+
+    if not helper.valid_token(request.form):
+        abort(403)
+
+    survey_id = request.form["id"]
+    if survey_service.delete_survey(survey_id):
+        return redirect("/")
+    return redirect(f"/surveys/{survey_id}")
 
 @surveys.route("/surveys/<survey_id>")
 def view_survey(survey_id):
@@ -80,7 +94,7 @@ def view_survey(survey_id):
 
     survey = survey_service.get_survey(survey_id)
     questions = survey_service.get_questions_of_survey(survey_id)
-    
+
     return render_template("surveys/view_survey.html", survey=survey, questions=questions, survey_id=survey_id)
 
 
@@ -105,6 +119,6 @@ def delete_question(question_id, survey_id):
     """
     if not helper.logged_in():
         return redirect("/")
-    
+
     survey_service.delete_question_from_survey(question_id)
     return redirect("/surveys/" + survey_id)


### PR DESCRIPTION
Enabled deleting surveys with a button found in surveys/<survey_id>. This functionality has also been robot tested. Other robot tests have also been updated and a new one created for making sure logged out users can't see any surveys. Some lint problems have been fixed too.