### PR TITLE
Tooltip UI element

### DIFF
--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -1,5 +1,5 @@
 /*
-! tailwindcss v3.2.0 | MIT License | https://tailwindcss.com
+! tailwindcss v3.1.8 | MIT License | https://tailwindcss.com
 */
 
 /*
@@ -410,12 +410,6 @@ video {
   height: auto;
 }
 
-/* Make elements with the HTML hidden attribute stay hidden by default */
-
-[hidden] {
-  display: none;
-}
-
 body {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
@@ -721,10 +715,6 @@ p {
   margin-bottom: 0.5rem;
 }
 
-.mr-4 {
-  margin-right: 1rem;
-}
-
 .mb-4 {
   margin-bottom: 1rem;
 }
@@ -819,6 +809,18 @@ p {
   width: 1.5rem;
 }
 
+.w-32 {
+  width: 8rem;
+}
+
+.w-20 {
+  width: 5rem;
+}
+
+.w-24 {
+  width: 6rem;
+}
+
 .min-w-full {
   min-width: 100%;
 }
@@ -907,14 +909,18 @@ p {
   gap: 1.5rem;
 }
 
+.gap-8 {
+  gap: 2rem;
+}
+
+.gap-9 {
+  gap: 2.25rem;
+}
+
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
-}
-
-.overflow-auto {
-  overflow: auto;
 }
 
 .overflow-hidden {
@@ -1299,9 +1305,9 @@ p {
 }
 
 .transition {
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-text-decoration-color, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-text-decoration-color, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1350,7 +1356,8 @@ p {
 }
 
 .hover\:underline:hover {
-  text-decoration-line: underline;
+  -webkit-text-decoration-line: underline;
+          text-decoration-line: underline;
 }
 
 .hover\:shadow-sm:hover {

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -470,6 +470,7 @@ p {
   border-color: rgb(203 213 225 / var(--tw-border-opacity));
   width: 10rem;
   /* 10rem */
+  max-width: 20rem;
   text-align: center;
   padding: 0.5rem;
   position: absolute;
@@ -478,7 +479,7 @@ p {
   bottom: 125%;
   left: 50%;
   margin-left: calc((10rem / 2) * -1);
-  /* With divided by 2 times -1 */
+  /*  (width/2)*-1 */
   opacity: 0;
   transition: opacity 0.3s;
 }

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -449,6 +449,56 @@ p {
   line-height: 1.5rem;
 }
 
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(51 65 85 / var(--tw-text-opacity));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  border-radius: 0.5rem;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(203 213 225 / var(--tw-border-opacity));
+  width: 10rem;
+  /* 10rem */
+  text-align: center;
+  padding: 0.5rem;
+  position: absolute;
+  z-index: 10;
+  visibility: hidden;
+  bottom: 125%;
+  left: 50%;
+  margin-left: calc((10rem / 2) * -1);
+  /* With divided by 2 times -1 */
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip .tooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #64748b transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}
+
 *, ::before, ::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
@@ -993,6 +1043,10 @@ p {
 
 .bg-opacity-60 {
   --tw-bg-opacity: 0.6;
+}
+
+.stroke-sky-400 {
+  stroke: #38bdf8;
 }
 
 .stroke-emerald-500 {

--- a/src/static/src/style.css
+++ b/src/static/src/style.css
@@ -49,6 +49,7 @@
         @apply  border;
         @apply border-slate-300;
         @apply w-40; /* 10rem */
+        @apply max-w-xs;
         @apply text-center;
         @apply p-2;
         @apply absolute;
@@ -56,7 +57,7 @@
         visibility: hidden;
         bottom: 125%;
         left: 50%;
-        margin-left: calc((10rem / 2) * -1); /* With divided by 2 times -1 */
+        margin-left: calc((10rem / 2) * -1); /*  (width/2)*-1 */
         opacity: 0;
         transition: opacity 0.3s;
     }

--- a/src/static/src/style.css
+++ b/src/static/src/style.css
@@ -34,4 +34,46 @@
     p {
         @apply text-base;
     }
+
+    .tooltip {
+        @apply relative;
+        @apply inline-block;
+    }
+      
+    .tooltip .tooltiptext {
+        @apply text-sm;
+        @apply bg-white;
+        @apply text-slate-700;
+        @apply shadow-sm;
+        @apply rounded-lg;
+        @apply  border;
+        @apply border-slate-300;
+        @apply w-40; /* 10rem */
+        @apply text-center;
+        @apply p-2;
+        @apply absolute;
+        @apply z-10;
+        visibility: hidden;
+        bottom: 125%;
+        left: 50%;
+        margin-left: calc((10rem / 2) * -1); /* With divided by 2 times -1 */
+        opacity: 0;
+        transition: opacity 0.3s;
+    }
+      
+    .tooltip .tooltiptext::after {
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        margin-left: -5px;
+        border-width: 5px;
+        border-style: solid;
+        border-color: #64748b transparent transparent transparent;
+      }
+      
+    .tooltip:hover .tooltiptext {
+        visibility: visible;
+        opacity: 1;
+    }
 }

--- a/src/templates/components/macros/form_elements.html
+++ b/src/templates/components/macros/form_elements.html
@@ -11,11 +11,9 @@
 {% set required_text = 'required' %}
 {% endif %}
 
-{% call field_wrapper_and_label(name, label_text) %}
 <input type="text" name="{{ name }}" placeholder="{{ placeholder }}" value="{{ value }}"
     class="bg-white border border-slate-300 text-gray-900 text-sm rounded-lg focus:invalid:border-rose-500 focus:ring-sky-500 focus:border-sky-500  block w-full p-2"
     {{ required_text }}>
-{% endcall %}
 
 {% endmacro %}
 
@@ -33,11 +31,9 @@
 {% endif %}
 
 
-{% call field_wrapper_and_label(name, label_text) %}
 <textarea type="text" name="{{name}}" placeholder="{{ placeholder }}"
     class="bg-white border border-slate-300 text-gray-900 text-sm rounded-lg focus:invalid:border-rose-500 focus:ring-sky-500 focus:border-sky-500 block w-full p-2"
     {{ required_text }}>{{ value }}</textarea>
-{% endcall %}
 
 {% endmacro %}
 
@@ -58,11 +54,9 @@
 {% set required_text = 'required' %}
 {% endif %}
 
-{% call field_wrapper_and_label(name, label_text) %}
 <input type="number" value="{{ value }}" name="{{ name }}" min="{{ min }}" max="{{ max }}" step="{{ step }}" placeholder="{{ placeholder }}" id="{{id}}"
     class="font-mono bg-white border border-slate-300 text-gray-900 text-sm rounded-lg focus:invalid:border-rose-500 focus:ring-sky-500 focus:border-sky-500 block w-full p-2"
     {{ required_text }}>
-{% endcall %}
 
 {% endmacro %}
 
@@ -108,3 +102,7 @@
 
 {# The HTML below is a fix for TailwindCSS to render a CSS containing colors used in these macros #}
 <div class="hover:bg-emerald-700 bg-emerald-500"></div>
+
+{% macro label(name, label_text) %}
+<label for="{{ name }}" class="text-gray-700 text-sm font-bold w-max">{{ label_text }}</label>
+{% endmacro %}

--- a/src/templates/components/macros/form_elements.html
+++ b/src/templates/components/macros/form_elements.html
@@ -87,22 +87,9 @@
 </button>
 {% endmacro %}
 
-{% macro field_wrapper_and_label(name, label_text) %}
-{# Wraps a given form input in a flexbox and attaches an appropriate label.
-    This macro is used with the call block.
-    Args:
-        name: Name used in the input element
-        label_text: Text to display in the label
-#}
-<div class="flex flex-col gap-2 w-full">
-    <label for="{{ name }}" class="text-gray-700 text-sm font-bold w-max">{{ label_text }}</label>
-    {{ caller() }}
-</div>
+{% macro label(name, label_text) %}
+<label for="{{ name }}" class="text-gray-700 text-sm font-bold w-max">{{ label_text }}</label>
 {% endmacro %}
 
 {# The HTML below is a fix for TailwindCSS to render a CSS containing colors used in these macros #}
 <div class="hover:bg-emerald-700 bg-emerald-500"></div>
-
-{% macro label(name, label_text) %}
-<label for="{{ name }}" class="text-gray-700 text-sm font-bold w-max">{{ label_text }}</label>
-{% endmacro %}

--- a/src/templates/components/macros/survey_elements.html
+++ b/src/templates/components/macros/survey_elements.html
@@ -79,9 +79,15 @@
     <summary class="text-slate-600 font-medium text-lg" style="cursor: pointer">Answer {{ index }}: {{ answer[1] }}</summary>
     <div class="flex flex-col gap-2">
         <div class="flex flex-grow"></div>
-        {{ form_elements.text_area("answer-" ~ index, "Answer", "", false, answer[1]) }}
-        {{ form_elements.number_input("points-" ~ index, "points-" ~ index, "Points", "", false, "-50", "50", "1",
+        <div class="flex flex-col gap-2 w-full">
+            {{ form_elements.label("answer-" ~ index, "Answer")}}
+            {{ form_elements.text_area("answer-" ~ index, "Answer", "", false, answer[1]) }}
+        </div>
+        <div class="flex flex-col gap-2 w-full">
+            {{ form_elements.label("points-" ~ index, "Points")}}
+            {{ form_elements.number_input("points-" ~ index, "points-" ~ index, "Points", "", false, "-50", "50", "1",
         answer[2]) }}
+        </div>      
         <div class="flex flex-grow"></div>
         {{ form_elements.submit_button("Delete answer", "destructive", "/surveys/%s/question/%s/answers/%s" % (survey.id, question_id, answer.id)) }}
     </div>

--- a/src/templates/components/macros/tooltip.html
+++ b/src/templates/components/macros/tooltip.html
@@ -1,0 +1,9 @@
+{% macro tooltip(text = "I am a tooltip") %}
+<div class="tooltip">
+    <svg xmlns="http://www.w3.org/2000/svg" class="stroke-sky-400 h-6 w-6" fill="none" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    <span class="tooltiptext">{{ text }}</span>
+</div>
+{% endmacro %}

--- a/src/templates/components/macros/tooltip.html
+++ b/src/templates/components/macros/tooltip.html
@@ -1,6 +1,6 @@
 {% macro tooltip(text = "I am a tooltip") %}
 <div class="tooltip">
-    <svg xmlns="http://www.w3.org/2000/svg" class="stroke-sky-400 h-6 w-6" fill="none" viewBox="0 0 24 24">
+    <svg xmlns="http://www.w3.org/2000/svg" class="stroke-sky-400 h-6 w-6" fill="none" viewBox="0 0 30 30">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
             d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>

--- a/src/templates/components/sections/survey_header.html
+++ b/src/templates/components/sections/survey_header.html
@@ -1,6 +1,5 @@
 {% import "components/macros/survey_elements.html" as survey_elements %}
 {% import "components/macros/buttons.html" as buttons %}
-{% import "components/macros/tooltip.html" as tooltip %}
 
 <div class="grid md:grid-cols-2 gap-6 lg:gap-8 items-center">
     <div class="flex flex-col gap-2">
@@ -10,7 +9,6 @@
     <div class="flex items-start md:justify-end gap-2">
         {{ buttons.link_button("Edit survey", "/surveys/%s/edit" % survey[0]) }}
         {{ buttons.modal_button("Delete survey", "delete", "survey-delete-button", "modal", "destructive") }}
-        {{ tooltip.tooltip() }}
     </div>
 
 </div>

--- a/src/templates/components/sections/survey_header.html
+++ b/src/templates/components/sections/survey_header.html
@@ -1,5 +1,6 @@
 {% import "components/macros/survey_elements.html" as survey_elements %}
 {% import "components/macros/buttons.html" as buttons %}
+{% import "components/macros/tooltip.html" as tooltip %}
 
 <div class="grid md:grid-cols-2 gap-6 lg:gap-8 items-center">
     <div class="flex flex-col gap-2">
@@ -9,6 +10,7 @@
     <div class="flex items-start md:justify-end gap-2">
         {{ buttons.link_button("Edit survey", "/surveys/%s/edit" % survey[0]) }}
         {{ buttons.modal_button("Delete survey", "delete", "survey-delete-button", "modal", "destructive") }}
+        {{ tooltip.tooltip() }}
     </div>
 
 </div>

--- a/src/templates/home/list_admins.html
+++ b/src/templates/home/list_admins.html
@@ -8,8 +8,11 @@
     <div class="flex flex-col px-6 py-4">
         <form action="/admins/new" method="POST">
             <div class="flex flex-col gap-4 items-start">
-            <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
-                {{ form_elements.text_input("email", "Email address", "", true, "") }}
+                <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
+                <div class="flex flex-col gap-2 w-full">
+                    {{ form_elements.label("email", "Email address") }}
+                    {{ form_elements.text_input("email", "Email address", "", true, "") }}
+                </div>
                 {{ form_elements.submit_button("Add user", "default", "/admins/new") }}
             </div>
         </form>
@@ -22,16 +25,16 @@
             </tr>
         </thead>
         <tbody>
-        {% for admin in admins %}
+            {% for admin in admins %}
             <tr>
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-500 text-left">{{admin[0]}}</td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-500 text-left">{{admin[1]}}</td>
             </tr>
-        {% endfor %}
+            {% endfor %}
         </tbody>
     </table>
     {% endcall %}
     </div>
-<br>
+    <br>
 </container>
 {% endblock %}

--- a/src/templates/questions/edit_question.html
+++ b/src/templates/questions/edit_question.html
@@ -30,9 +30,9 @@
                         <div class="flex-grow border-t border-slate-200"></div>
                     </div>
                     <fieldset>
-                        <div class="flex flex-row gap-4">
+                        <div class="flex flex-row flex-wrap gap-4">
                             {% for category in categories %}
-                            <div class="flex flex-col gap-2 w-full">
+                            <div class="flex flex-col gap-2 w-24">
                                 {{ form_elements.label("cat" ~ category[0], category[1])}}
                                 {{ form_elements.number_input("cat" ~ category[0], "cat-" ~ category[0] ~ "-weight",
                                 category[1], "0", false, "-100", "100",

--- a/src/templates/questions/edit_question.html
+++ b/src/templates/questions/edit_question.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% import "components/macros/form_elements.html" as form_elements %}
 {% import "components/macros/survey_elements.html" as survey_elements %}
+{% import "components/macros/tooltip.html" as tooltip %}
 {% block content %}
 <div class="flex flex-col gap-6 items-start w-full">
     <h1 class="text-slate-700">Add question to {{ survey.name }}</h1>
@@ -18,8 +19,9 @@
                         {{ form_elements.label("text", "Question") }}
                         {{ form_elements.text_area("text", "Question", "", false, text) }}
                     </div>
-                    <div class="relative flex py-5 items-center">
-                        <span class="flex-shrink text-slate-600 mr-4">Category weights</span>
+                    <div class="relative flex py-5 items-center gap-2">
+                        <span class="flex-shrink text-slate-600">Category weights</span>
+                        {{ tooltip.tooltip("Category weights affect how each questions points are calculated") }}
                         <div class="flex-grow border-t border-slate-200"></div>
                     </div>
                     <fieldset>
@@ -53,8 +55,9 @@
                     </div>
                     <div class="flex flex-col gap-2 w-full">
                         {{ form_elements.label("points", "Points")}}
-                        {{ form_elements.number_input("points", "new-answer-points", "Points", "0", false, "-100", "100",
-                    "1") }}
+                        {{ form_elements.number_input("points", "new-answer-points", "Points", "0", false, "-100",
+                        "100",
+                        "1") }}
                     </div>
                     {{ form_elements.submit_button("Add answer", "creation", "/surveys/%s/questions/%s/new-answer" %
                     (survey.id, question_id)) }}

--- a/src/templates/questions/edit_question.html
+++ b/src/templates/questions/edit_question.html
@@ -14,7 +14,10 @@
             <div class="flex flex-col gap-6">
                 {% call survey_elements.card() %}
                 <div class="flex flex-col gap-4">
-                    {{ form_elements.text_area("text", "Question", "", false, text) }}
+                    <div class="flex flex-col gap-2 w-full">
+                        {{ form_elements.label("text", "Question") }}
+                        {{ form_elements.text_area("text", "Question", "", false, text) }}
+                    </div>
                     <div class="relative flex py-5 items-center">
                         <span class="flex-shrink text-slate-600 mr-4">Category weights</span>
                         <div class="flex-grow border-t border-slate-200"></div>
@@ -22,9 +25,13 @@
                     <fieldset>
                         <div class="flex flex-row gap-4">
                             {% for category in categories %}
-                            {{ form_elements.number_input("cat" ~ category[0], "cat-" ~ category[0] ~ "-weight", category[1], "0", false, "-100", "100",
-                            "1",
-                            weights[category[1]]) }}
+                            <div class="flex flex-col gap-2 w-full">
+                                {{ form_elements.label("cat" ~ category[0], category[1])}}
+                                {{ form_elements.number_input("cat" ~ category[0], "cat-" ~ category[0] ~ "-weight",
+                                category[1], "0", false, "-100", "100",
+                                "1",
+                                weights[category[1]]) }}
+                            </div>
                             {% endfor %}
                         </div>
                     </fieldset>
@@ -40,9 +47,17 @@
                 {% call survey_elements.card() %}
                 <div class="flex flex-col gap-4 items-start">
                     <h3 class="text-slate-600">New answer</h3>
-                    {{ form_elements.text_area("answer_text", "Answer", "", false) }}
-                    {{ form_elements.number_input("points", "new-answer-points", "Points", "0", false, "-100", "100", "1") }}
-                    {{ form_elements.submit_button("Add answer", "creation", "/surveys/%s/questions/%s/new-answer" % (survey.id, question_id)) }}
+                    <div class="flex flex-col gap-2 w-full">
+                        {{ form_elements.label("answer_text", "Answer")}}
+                        {{ form_elements.text_area("answer_text", "Answer", "", false) }}
+                    </div>
+                    <div class="flex flex-col gap-2 w-full">
+                        {{ form_elements.label("points", "Points")}}
+                        {{ form_elements.number_input("points", "new-answer-points", "Points", "0", false, "-100", "100",
+                    "1") }}
+                    </div>
+                    {{ form_elements.submit_button("Add answer", "creation", "/surveys/%s/questions/%s/new-answer" %
+                    (survey.id, question_id)) }}
                 </div>
                 {% endcall %}
             </div>

--- a/src/templates/questions/edit_question.html
+++ b/src/templates/questions/edit_question.html
@@ -34,9 +34,8 @@
                             {% for category in categories %}
                             <div class="flex flex-col gap-2 w-24">
                                 {{ form_elements.label("cat" ~ category[0], category[1])}}
-                                {{ form_elements.number_input("cat" ~ category[0], "cat-" ~ category[0] ~ "-weight",
-                                category[1], "0.1", false, "-100", "100",
-                                "1",
+                                {{ form_elements.number_input("cat" ~ category[0], "cat-" ~ category[0] ~ "-weight", category[1], "0", false, "-100", "100",
+                                "0.1",
                                 weights[category[1]]) }}
                             </div>
                             {% endfor %}

--- a/src/templates/surveys/edit_category.html
+++ b/src/templates/surveys/edit_category.html
@@ -2,55 +2,70 @@
 {% import "components/macros/form_elements.html" as form_elements %}
 {% import "components/macros/survey_elements.html" as survey_elements %}
 {% block content %}
-    {% if edit %}
-        <h2 class="text-slate-700">Edit category</h2>
-    {% else %}
-        <h2 class="text-slate-700">New Category</h2>
-    {% endif %}
-    <br>
-    <form action="/edit_category" method="POST">
-        <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
-        <input type="hidden" name="survey_id" id="survey_id" value={{survey_id}}>
-        <input type="hidden" name="category_id" id="category_id" value={{category_id}}>
-        <input type="hidden" name="edit" id="edit" value="{{ edit }}">
-        <input type="hidden" name="stay" id="stay"></input>
-        <div class="flex flex-col gap-6">
-            {% call survey_elements.card() %}
+{% if edit %}
+<h2 class="text-slate-700">Edit category</h2>
+{% else %}
+<h2 class="text-slate-700">New Category</h2>
+{% endif %}
+{% call survey_elements.card() %}
+<form action="/edit_category" method="POST">
+    <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
+    <input type="hidden" name="survey_id" id="survey_id" value={{survey_id}}>
+    <input type="hidden" name="category_id" id="category_id" value={{category_id}}>
+    <input type="hidden" name="edit" id="edit" value="{{ edit }}">
+    <input type="hidden" name="stay" id="stay"></input>
+    <div class="flex flex-col gap-6">
+        <div class="flex flex-col gap-4">
+            <div class="flex flex-col gap-2 w-full">
+                {{ form_elements.label("name", "Name") }}
                 {{ form_elements.text_area("name", "Name", "", true, name) }}
-                <br>
+            </div>
+            <div class="flex flex-col gap-2 w-full">
+                {{ form_elements.label("description", "Description") }}
                 {{ form_elements.text_area("description", "Description", "", true, description) }}
-                <br>
-                {% if content_links %}
-                <br>
-                    <div>
-                        {% for content in content_links %}
-                        {{ form_elements.text_area('type_'+loop.index0 | string, "Content link type", "", false, value=content['type'])}}
-                        <br>
-                        {{ form_elements.text_area('url_'+loop.index0 | string, "Content link URL", "", false, value=content['url'])}}
-                        <br>
-                        <br>
-                        {% endfor %}
-                    </div>
-                {% endif %}
-                {{ form_elements.submit_button("Save", "default", "/edit_category") }}
-            {% endcall %}
+            </div>
+            {% if content_links %}
+            <div class="flex flex-col gap-2 w-full">
+                {% for content in content_links %}
+                <div class="relative flex py-5 items-center">
+                    <span class="flex-shrink text-slate-600 mr-4">Content link {{ loop.index }}</span>
+                    <div class="flex-grow border-t border-slate-200"></div>
+                </div>
+                <div class="flex flex-col gap-2 w-full">
+                    {{ form_elements.label('type_'+loop.index0 | string, "Content link type") }}
+                    {{ form_elements.text_area('type_'+loop.index0 | string, "Content link type", "", false,
+                    value=content['type'])}}
+                </div>
+                <div class="flex flex-col gap-2 w-full">
+                    {{ form_elements.label('url_'+loop.index0 | string, "Content link URL") }}
+                    {{ form_elements.text_area('url_'+loop.index0 | string, "Content link URL", "", false,
+                    value=content['url'])}}
+                </div>
+                {% endfor %}
+            </div>
+            {% endif %}
+            {{ form_elements.submit_button("Save", "default") }}
         </div>
+    </div>
+    {% endcall %}
     {% if edit %}
-        <br>
-        <br>
-        <h2 class="text-slate-700">Add content link</h2>
-        <br>
-        <form action="/add_content_link" method="POST">
-            <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
-            <input type="hidden" name="survey_id" id="survey_id" value={{survey_id}}>
-            <input type="hidden" name="category_id" id="category_id" value={{category_id}}>
-            {% call survey_elements.card() %}
-                {{ form_elements.text_area("new_type", "Type", "", false)}}
-                <br>
-                {{ form_elements.text_area("new_url", "URL", "", false)}}
-                <br>
-                {{ form_elements.submit_button("Add", "creation", "/add_content_link") }}
-            {% endcall %}
-    {% endif %}
+    <h2 class="text-slate-700">Add content link</h2>
+    {% call survey_elements.card() %}
+    <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
+    <input type="hidden" name="survey_id" id="survey_id" value={{survey_id}}>
+    <input type="hidden" name="category_id" id="category_id" value={{category_id}}>
+    <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-2 w-full">
+            {{ form_elements.label("new_type", "Type") }}
+            {{ form_elements.text_area("new_type", "Type", "", false)}}
+        </div>
+        <div class="flex flex-col gap-2 w-full">
+            {{ form_elements.label("new_url", "URL") }}
+            {{ form_elements.text_area("new_url", "URL", "", false)}}
+        </div>
+        {{ form_elements.submit_button("Add", "creation", "/add_content_link") }}
+    </div>
+</form>
+{% endcall %}
+{% endif %}
 {% endblock %}
-

--- a/src/templates/surveys/edit_category.html
+++ b/src/templates/surveys/edit_category.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% import "components/macros/form_elements.html" as form_elements %}
 {% import "components/macros/survey_elements.html" as survey_elements %}
+{% import "components/macros/tooltip.html" as tooltip %}
 {% block content %}
 {% if edit %}
 <h2 class="text-slate-700">Edit category</h2>
@@ -27,8 +28,9 @@
             {% if content_links %}
             <div class="flex flex-col gap-2 w-full">
                 {% for content in content_links %}
-                <div class="relative flex py-5 items-center">
-                    <span class="flex-shrink text-slate-600 mr-4">Content link {{ loop.index }}</span>
+                <div class="relative flex py-5 items-center gap-2">
+                    <span class="flex-shrink text-slate-600 ">Content link {{ loop.index }}</span>
+                    {{ tooltip.tooltip("A content link is displayed to the user after filling the survey") }}
                     <div class="flex-grow border-t border-slate-200"></div>
                 </div>
                 <div class="flex flex-col gap-2 w-full">

--- a/src/templates/surveys/edit_survey.html
+++ b/src/templates/surveys/edit_survey.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% import "components/macros/form_elements.html" as form_elements %}
 {% import "components/macros/survey_elements.html" as survey_elements %}
+{% import "components/macros/tooltip.html" as tooltip %}
 {% block content %}
 <div class="grid lg:grid-cols-2 grid-cols-1 gap-4 items-start">
 
@@ -16,12 +17,25 @@
         <div class="flex flex-col gap-4 items-start">
             <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
             <input type="hidden" name="survey_id" type="text" class="border" readonly="readonly"
-                    value="{{ survey[0] }}">
-            {{ form_elements.text_input("name", "Name", "DevOps Survey", true, survey.name) }}
-            {{ form_elements.text_input("title", "Title", "Are you a DevOps bop or flop?", true, survey.title_text) }}
-            {{ form_elements.text_area("description", "Description", "Do you know the difference between docker and
-            kubernetes? Define your skills here!",
-            true, survey.survey_text) }}
+                value="{{ survey[0] }}">
+            <div class="flex flex-col gap-2 w-full">
+                {{ form_elements.label("name", "Name") }}
+                {{ form_elements.text_input("name", "Name", "DevOps Survey", true, survey.name) }}
+            </div>
+            <div class="flex flex-col gap-2 w-full">
+                {{ form_elements.label("title", "Title") }}
+                {{ form_elements.text_input("title", "Title", "Are you a DevOps bop or flop?", true, survey.title_text)
+                }}
+            </div>
+            <div class="flex flex-col gap-2 w-full">
+                <div class="flex flex-row gap-2 w-full">
+                    {{ form_elements.label("survey", "Description")}}
+                    {{ tooltip.tooltip("A flavor text for the survey") }}
+                </div>
+                {{ form_elements.text_area("description", "Description", "Do you know the difference between docker and
+                kubernetes? Define your skills here!",
+                true, survey.survey_text) }}
+            </div>
             {{ form_elements.submit_button("Save survey") }}
         </div>
     </form>

--- a/src/templates/surveys/new_survey.html
+++ b/src/templates/surveys/new_survey.html
@@ -2,6 +2,7 @@
 {% import "components/macros/form_elements.html" as form_elements %}
 {% import "components/macros/buttons.html" as buttons %}
 {% import "components/macros/survey_elements.html" as survey_elements %}
+{% import "components/macros/tooltip.html" as tooltip %}
 {% block content %}
 <div class="grid lg:grid-cols-2 grid-cols-1 gap-4 items-start">
     <div class="flex flex-col gap-4">
@@ -15,7 +16,11 @@
     <form action="/surveys/new-survey" method="POST">
         <div class="flex flex-col gap-4 items-start">
             <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
-            {{ form_elements.text_input("name", "Name", "DevOps Survey", true) }}
+            <div class="flex flex-row gap-2 w-full items-end">
+                {{ form_elements.text_input("name", "Name", "DevOps Survey", true) }}
+                {{ tooltip.tooltip("A short name for your survey.") }}                
+            </div>
+            
             {{ form_elements.text_input("title", "Title", "Are you a DevOps bop or flop?", true) }}
             {{ form_elements.text_area("survey", "Description", "Do you know the difference between docker and kubernetes? Define your skills here!",
             true) }}

--- a/src/templates/surveys/new_survey.html
+++ b/src/templates/surveys/new_survey.html
@@ -16,14 +16,24 @@
     <form action="/surveys/new-survey" method="POST">
         <div class="flex flex-col gap-4 items-start">
             <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
-            <div class="flex flex-row gap-2 w-full items-end">
+            <div class="flex flex-col gap-2 w-full">
+                {{ form_elements.label("name", "Name") }}
                 {{ form_elements.text_input("name", "Name", "DevOps Survey", true) }}
-                {{ tooltip.tooltip("A short name for your survey.") }}                
             </div>
-            
-            {{ form_elements.text_input("title", "Title", "Are you a DevOps bop or flop?", true) }}
-            {{ form_elements.text_area("survey", "Description", "Do you know the difference between docker and kubernetes? Define your skills here!",
-            true) }}
+            <div class="flex flex-col gap-2 w-full">
+                {{ form_elements.label("title", "Title") }}
+                {{ form_elements.text_input("title", "Title", "Are you a DevOps bop or flop?", true) }}
+            </div>
+            <div class="flex flex-col gap-2 w-full">
+                <div class="flex flex-row gap-2 w-full">
+                    {{ form_elements.label("survey", "Description")}}
+                    {{ tooltip.tooltip("A flavor text for the survey") }}
+                </div>
+                {{ form_elements.text_area("survey", "Description", "Do you know the difference between docker and
+                kubernetes? Define your skills here!",
+                true) }}
+            </div>
+
             {{ form_elements.submit_button("Create survey") }}
         </div>
     </form>


### PR DESCRIPTION
Made a tooltip UI macro. The tooltip works using the CSS :hover selector. This was the most straightforward solution but can affect mobile usability since hovering and mobile devices is a tricky combo.

Had to make changes to the form_elements macros. To place the tooltip in a logical place (next to the label of the input) I removed the field_wrapper_and_label macro. Input elements now require two macro calls wrapped in a flexbox. An input with a label and a tooltip is created like this:
```
<div class="flex flex-col gap-2 w-full"> (creates a vertical stack where elements are in two rows)
    <div class="flex flex-row gap-2 w-full"> (creates a horizontal stack of label and tooltip)
        {{ form_elements.label() }}
        {{ tooltip.tooltip() }}
    </div>
    {{ form_elements.text_area() }}
</div>
```