### PR TITLE
Dev editing survey results

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -202,6 +202,8 @@ def empty_dir():
 
 
 def check_cutoff_points(cutoffs):
+    if "" in cutoffs:
+        return "There is a result without a cutoff value"
     if "1.0" not in cutoffs:
         return "There must be a cutoff from maximum with a value of 1.0"
     set_list = set(cutoffs)

--- a/src/helper.py
+++ b/src/helper.py
@@ -199,3 +199,18 @@ def empty_dir():
     except OSError:
         return False
     return True
+
+
+def check_cutoff_points(cutoffs):
+    if 1 not in cutoffs:
+        return "There must be a cutoff from maximum with a value of 1"
+    set_list = set(cutoffs)
+    unique_list = list(set_list)
+    if len(unique_list) != len(cutoffs):
+        return "There must not be any identical cutoff values"
+    for cutoff in cutoffs:
+        if 0 <= cutoff <= 1:
+            continue
+        else:
+            return "Cutoff values must be between 0 and 1"
+    return "Correct"

--- a/src/helper.py
+++ b/src/helper.py
@@ -202,16 +202,27 @@ def empty_dir():
 
 
 def check_cutoff_points(cutoffs):
+    """ Takes a list of cutoff points and checks there
+    are no empty entries, no duplicate entries, no
+    entries not between 0-1, and that there is a cutoff
+    with a value of 1 """
     if "" in cutoffs:
         return "There is a result without a cutoff value"
-    if "1.0" not in cutoffs:
-        return "There must be a cutoff from maximum with a value of 1.0"
-    set_list = set(cutoffs)
-    unique_list = list(set_list)
-    if len(unique_list) != len(cutoffs):
-        return "There must not be any identical cutoff values"
+    float_cutoffs = []
     for cutoff in cutoffs:
+        float_cutoffs.append(float(cutoff))
         if 0 <= float(cutoff) <= 1:
+            continue
+        else:
+            return "Cutoff values must be between 0 and 1"
+    if 1.0 not in float_cutoffs:
+        return "There must be a cutoff from maximum with a value of 1.0"
+    set_list = set(float_cutoffs)
+    unique_list = list(set_list)
+    if len(unique_list) != len(float_cutoffs):
+        return "There must not be any identical cutoff values"
+    for cutoff in float_cutoffs:
+        if 0 <= cutoff <= 1:
             continue
         else:
             return "Cutoff values must be between 0 and 1"

--- a/src/helper.py
+++ b/src/helper.py
@@ -202,14 +202,14 @@ def empty_dir():
 
 
 def check_cutoff_points(cutoffs):
-    if 1 not in cutoffs:
-        return "There must be a cutoff from maximum with a value of 1"
+    if "1.0" not in cutoffs:
+        return "There must be a cutoff from maximum with a value of 1.0"
     set_list = set(cutoffs)
     unique_list = list(set_list)
     if len(unique_list) != len(cutoffs):
         return "There must not be any identical cutoff values"
     for cutoff in cutoffs:
-        if 0 <= cutoff <= 1:
+        if 0 <= float(cutoff) <= 1:
             continue
         else:
             return "Cutoff values must be between 0 and 1"

--- a/src/repositories/survey_repository.py
+++ b/src/repositories/survey_repository.py
@@ -999,9 +999,9 @@ class SurveyRepository:
     def get_survey_results(self, survey_id):
         """Get the results of a survey
 
-        Return table with columns: id, text, cutoff_from_maxpoints, createdAt, updatedAt, surveyId"""
+        Return table with columns: id, text, cutoff_from_maxpoints"""
         sql = """
-            SELECT id, text, cutoff_from_maxpoints, "createdAt", "updatedAt", "surveyId"
+            SELECT id, text, cutoff_from_maxpoints
             FROM "Survey_results"
             WHERE "surveyId"=:survey_id
             ORDER BY cutoff_from_maxpoints

--- a/src/repositories/survey_repository.py
+++ b/src/repositories/survey_repository.py
@@ -1091,3 +1091,28 @@ class SurveyRepository:
         if not category_results:
             return None
         return category_results
+
+    def update_survey_results(self, original_results, new_results, survey_id):
+        """ Goes through the lists of results and updates each
+        result where the original and new result don't match.
+        This function is not called if there are no differences
+        so the updatedAt of the survey in question will also be
+        updated and True is returned. """
+
+        for i in range(len(original_results)):
+            if original_results[i] != new_results[i]:
+                sql = """
+                UPDATE "Survey_results"
+                SET
+                    text=:text,
+                    cutoff_from_maxpoints=:cutoff,
+                    "updatedAt"=NOW()
+                WHERE id=:result_id
+                """
+                values = {
+                    "text": new_results[i][1],
+                    "cutoff": new_results[i][2],
+                    "result_id": new_results[i][0]}
+                db.session.execute(sql, values)
+        #update updatedAt
+        db.session.commit()

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -522,7 +522,7 @@ class SurveyService:
     def get_survey_results(self, survey_id):
         """Fetch the results of the given survey
 
-        Returns a table with columns: id, text, cutoff_from_maxpoints, createdAt, updatedAt, "surveyId"
+        Returns a table with columns: id, text, cutoff_from_maxpoints
         """
         return self.survey_repository.get_survey_results(survey_id)
 

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -533,4 +533,8 @@ class SurveyService:
 
         return self.survey_repository.delete_survey_result(result_id)
 
+    def update_survey_results(self, original_results, new_results, survey_id):
+        """Updates the original results of a survey to new ones"""
+        return self.survey_repository.update_survey_results(original_results,new_results,survey_id)
+
 survey_service = SurveyService(SurveyRepository())

--- a/src/templates/components/macros/survey_elements.html
+++ b/src/templates/components/macros/survey_elements.html
@@ -105,10 +105,7 @@
 #}
 {% call card() %}
 
-<form action="/update_survey_result" method="POST">
-  <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
-  <input type="hidden" name="result_id" id="result_id" value="{{ result[0] }}">
-  <input type="hidden" name="survey_id" id="survey_id" value="{{ result[5] }}">
+
 <details id="expandable-result-{{ index }}">
     <summary class="text-slate-600 font-medium text-lg" style="cursor: pointer">Result at cutoff point {{ result[2] }}:</summary>
     <div class="flex flex-col gap-2">
@@ -125,11 +122,7 @@
             ) }}
         </div>      
         <div class="flex flex-grow"></div>
-        
-        {% if not hide_delete_button %}
-        {% set button_id = "delete%s" % result[0] %}
-        {{ form_elements.submit_button("Delete result", "destructive", id=button_id) }}
-        {% endif %}
+
     </div>
 </details>
 </form>

--- a/src/templates/components/macros/survey_elements.html
+++ b/src/templates/components/macros/survey_elements.html
@@ -122,7 +122,9 @@
             ) }}
         </div>      
         <div class="flex flex-grow"></div>
-
+        {% if not hide_delete_button %}
+        {{ form_elements.submit_button("Delete result", "destructive", "/delete_survey_result/%s" % (result[0])) }}
+        {% endif %}
     </div>
 </details>
 </form>

--- a/src/templates/components/macros/survey_elements.html
+++ b/src/templates/components/macros/survey_elements.html
@@ -106,7 +106,7 @@
 <form action="/update_survey_result" method="POST">
   <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
   <input type="hidden" name="result_id" id="result_id" value="{{ result[0] }}">
-  <input type="hidden" name="survey_id" id="survey_id" value="{{ result[5] }}">  
+  <input type="hidden" name="survey_id" id="survey_id" value="{{ result[5] }}">
 <details id="expandable-result-{{ index }}">
     <summary class="text-slate-600 font-medium text-lg" style="cursor: pointer">Result at cutoff point {{ result[2] }}:</summary>
     <div class="flex flex-col gap-2">
@@ -121,9 +121,7 @@
         result[2]) }}
         </div>      
         <div class="flex flex-grow"></div>
-        {% set button_id = "update%s" % result_id %}        
-        {{ form_elements.submit_button("Update result", id=button_id) }}
-        
+
         {% if not hide_delete_button %}
         {% set button_id = "delete%s" % result_id %}
         {{ form_elements.submit_button("Delete result", "destructive", id=button_id) }}

--- a/src/templates/surveys/edit_survey_results.html
+++ b/src/templates/surveys/edit_survey_results.html
@@ -14,6 +14,7 @@
     <form class="w-full" action="/surveys/{{ survey.id }}/new-survey-result" method="POST">
         <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
         <input type="hidden" name="survey_id" id="survey_id" value="{{ survey.id }}">
+        <input type="hidden" name="results" id="results" value="{{ results }}">
         <div class="grid grid-cols-2 gap-4">
             <div class="flex flex-col gap-6">
                 {% call survey_elements.card() %}
@@ -26,16 +27,14 @@
                             {% set lower_bound = 0.0 %}
                         {% endif %}
                             {{ form_elements.label("text", "Result text") }}
-                            {{ form_elements.text_area("text", "Result", "Your skills in this topic are excellent!", true, text) }}
+                            {{ form_elements.text_area("text", "Result", "Your skills in this topic are excellent!", false, text) }}
                             {{ form_elements.label("cutoff", "Cutoff from maximum points") }}
-                            {{ form_elements.number_input("cutoff", "new-cutoff", "Cutoff from max points", 1.0, true, lower_bound, upper_bound, 0.01, 1.0) }}
+                            {{ form_elements.number_input("cutoff", "new-cutoff", "Cutoff from max points", 1.0, false, lower_bound, upper_bound, 0.01, 1.0) }}
                     </div>
-                    {{ form_elements.submit_button("Create new result") }}
+                    {{ form_elements.submit_button("Save changes") }}
                 </div>                    
             </div>
-            INSIDE
     </form>
-    OUTSIDE
     </div>
     <div class="w-full">
       {% endcall %}

--- a/src/tests/helper_test.py
+++ b/src/tests/helper_test.py
@@ -350,3 +350,15 @@ def empty_dir_test():
 
     assert file_count_before > 1
     assert file_count_after == 1
+
+def test_check_cutoff_points():
+    no_one = ["0.5","0.7","0.1"]
+    duplicates = ["0.5","0.5","0.1","1"]
+    not_in_range = ["0.5","2","-0.3","1.0"]
+    empty_cutoff = ["0.5","0.2","","1"]
+    all_good_man = ["0.9","0.5","0.1","1"]
+    assert helper.check_cutoff_points(no_one) == "There must be a cutoff from maximum with a value of 1.0"
+    assert helper.check_cutoff_points(duplicates) == "There must not be any identical cutoff values"
+    assert helper.check_cutoff_points(not_in_range) == "Cutoff values must be between 0 and 1"
+    assert helper.check_cutoff_points(empty_cutoff) == "There is a result without a cutoff value"
+    assert helper.check_cutoff_points(all_good_man) == "Correct"

--- a/src/tests/robot_tests/resource_manage_results.robot
+++ b/src/tests/robot_tests/resource_manage_results.robot
@@ -9,8 +9,13 @@ Set Result Cutoff
     Input Text  cutoff  ${value}
 
 Save Result
-    Click Button  Create new result
+    Click Button  Save changes
 
 Expand Result Card
     [Arguments]  ${result_index}
     Click Element  id:expandable-result-${result_index}
+
+Edit Result
+    [Arguments]  ${result}  ${cutoff}  ${id}
+    Input Text  result-${id}  ${result}
+    Input Text  cutoff-${id}  ${cutoff}

--- a/src/tests/robot_tests/survey_results.robot
+++ b/src/tests/robot_tests/survey_results.robot
@@ -19,7 +19,6 @@ User Can Create New Survey Result
      Expand Result Card  1
      Page Should Contain  You most resemble an African elephant
 
-
 First Survey Result Must Have Cutoff Value Of One
     Go To Survey  7
     Click Link  Manage results
@@ -47,6 +46,7 @@ Survey Results Can't Have Duplicate Cutoff Values
     Expand Result Card  1
     Expand Result Card  2
     Page Should Not Contain  You don't look like an elephant at all
+    Page Should Contain  There must not be any identical cutoff values
 
 Subsequent Survey Results Must Have Cutoff Value Between 0 And 1
     Go To Survey  8
@@ -74,3 +74,28 @@ Survey Result With Cutoff Value One Can not Be Deleted
     Expand Result Card  1
     Page Should Not Contain  Delete
 
+Survey Result Can Be Edited
+    Go To Survey  8
+    Click Link  Manage results
+    Set Result Text  You hate elephants
+    Set Result Cutoff  0
+    Save Result
+    Page Should Contain  Result at cutoff point 0.0:
+    Expand Result Card  1
+    Page Should Contain  You hate elephants
+    Edit Result  You love elephants  0.98  1
+    Save Result
+    Page Should Contain  Result at cutoff point 0.98:
+    Expand Result Card  1
+    Page Should Contain  You love elephants
+
+Survey Result Cannot Be Edited To Have Duplicate Cutoffs
+    Go To Survey  8
+    Click Link  Manage results
+    Expand Result Card  1
+    Page Should Contain  You love elephants
+    Edit Result  You hate elephants  1  1
+    Save Result
+    Page Should Contain  There must not be any identical cutoff values
+    Expand Result Card  1
+    Page Should Contain  You love elephants

--- a/src/views/surveys.py
+++ b/src/views/surveys.py
@@ -154,6 +154,8 @@ def new_question_post(survey_id):
             answer_id = original_answers[i][0]
             answer = request.form[f"answer-{i+1}"]
             points = request.form[f"points-{i+1}"]
+            if points == "":
+                points = 0
             new_answers.append((answer_id, answer, points))
         survey_service.update_question(
             question_id, text, category_weights, original_answers, new_answers)
@@ -462,7 +464,8 @@ def new_survey_result_post(survey_id):
             new_results.append((result_id,result,cutoff))
         cutoffs_correct = helper.check_cutoff_points(cutoff_values)
         if cutoffs_correct != "Correct":
-            return cutoffs_correct
+            flash(cutoffs_correct, "error")
+            return redirect(f"/surveys/{survey_id}/new-survey-result")
         if original_results != new_results:
             survey_service.update_survey_results(original_results,new_results,survey_id)
     if text and cutoff_value:
@@ -470,25 +473,16 @@ def new_survey_result_post(survey_id):
 
     return redirect(f"/surveys/{survey_id}/new-survey-result")
 
-@surveys.route("/update_survey_result", methods=["POST"])
-def delete_survey_result():
+@surveys.route("/delete_survey_result/<result_id>", methods=["POST"])
+def delete_survey_result(result_id):
     """Update or delete the given survey result
     """
-    result_id = request.form["result_id"]
     survey_id = request.form["survey_id"]
-    action = request.form['submit']
-
-    if action == "Delete result":
-        survey_service.delete_survey_result(result_id)
-
-    if action == "Update result":
-        # TODO: Implement result update
-        # survey_service.update_survey_result(result_id)
-        print(f"Update result: {result_id}", flush=True)
+    survey_service.delete_survey_result(result_id)
 
     return redirect(f"/surveys/{survey_id}/new-survey-result")
-    
-        
+
+
 @surveys.route("/surveys")
 def view_surveys():
     """Redirecting method"""

--- a/src/views/surveys.py
+++ b/src/views/surveys.py
@@ -443,8 +443,9 @@ def new_survey_result_post(survey_id):
         cutoffs_correct = helper.check_cutoff_points(cutoff_values)
         if cutoffs_correct != "Correct":
             return cutoffs_correct
-        survey_service.update_survey_results(original_results,new_results)
-    elif text and cutoff_value:
+        if original_results != new_results:
+            survey_service.update_survey_results(original_results,new_results,survey_id)
+    if text and cutoff_value:
         survey_service.create_survey_result(survey_id, text, cutoff_value)
 
     return redirect(f"/surveys/{survey_id}/new-survey-result")

--- a/src/views/testi.py
+++ b/src/views/testi.py
@@ -1,0 +1,1 @@
+print(float("1"))


### PR DESCRIPTION
Enabled editing survey results. Removed the update option from each survey result and made it so that Save changes updates each result and creates a new one if text and a cutoff value have been provided to it. Fixed a bug where removing the points of an answer would result in a DataError when editing questions. Made a helper function for checking cutoff values which can be used for editing category results. 