### PR TITLE
When creating new survey a survey result for cutoff 1 is created

### DIFF
--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -46,8 +46,15 @@ class SurveyService:
         """
 
         self._validate_survey_details(name, title, description)
+        survey_id = self.survey_repository.create_survey(name, title, description)
+        if survey_id:
+            survey_result_text = "Your skills in this topic are excellent!"
+            cutoff_from_maxpts = 1.0
+            self.create_survey_result(survey_id,
+                                      survey_result_text,
+                                      cutoff_from_maxpts)
 
-        return self.survey_repository.create_survey(name, title, description)
+        return survey_id
 
     def get_survey(self, survey_id: str):
         """
@@ -355,14 +362,14 @@ class SurveyService:
         """
         category_id = self.survey_repository.create_category(
             survey_id, name, description, content_links)
-
-        category_result_text = "Your skills in this topic are excellent!"
-        cutoff_from_maxpts = 1.0
-        self.create_category_result(
-            category_id,
-            category_result_text,
-            cutoff_from_maxpts
-        )
+        if category_id:
+            category_result_text = "Your skills in this topic are excellent!"
+            cutoff_from_maxpts = 1.0
+            self.create_category_result(
+                category_id,
+                category_result_text,
+                cutoff_from_maxpts
+            )
         
         return category_id
 

--- a/src/tests/robot_tests/create_survey.robot
+++ b/src/tests/robot_tests/create_survey.robot
@@ -11,7 +11,6 @@ Test Setup  Go To Home Page
 Logged In User Can Create Surveys
     Go To Backdoor Login Page
     Login With Correct Credentials
-    Go To Home Page
     Click Link  New survey
     Make A Survey
     Element Should Be Visible  id:notification

--- a/src/tests/robot_tests/edit_category.robot
+++ b/src/tests/robot_tests/edit_category.robot
@@ -56,6 +56,8 @@ Logged In User Can Create Categories Without Content Links
     Create New Category Without Content Links
     Page Should Contain  abc
     Page Should Contain  123
+    Page Should Contain  Your skills in this topic are excellent!
+    Element Attribute Value Should Be  cutoff-17  value  1.0
 
 Logged Out User Cannot Create Categories
     Logout

--- a/src/tests/robot_tests/survey_results.robot
+++ b/src/tests/robot_tests/survey_results.robot
@@ -78,8 +78,9 @@ Survey Result With Cutoff Value One Can not Be Deleted
 New Survey Has Survey Result For Cutoff Value 1.0
     Click Link  New survey
     Make A Survey
-    Page Should Contain  100.0% of max points returns user:
+    Page Should Contain  0%-100.0% of max points returns user
     Page Should Contain  Your skills in this topic are excellent!
+
 Survey Result Can Be Edited
     Go To Survey  8
     Click Link  Manage results

--- a/src/tests/robot_tests/survey_results.robot
+++ b/src/tests/robot_tests/survey_results.robot
@@ -2,6 +2,7 @@
 Resource  resource.robot
 Resource  resource_login.robot
 Resource  resource_manage_results.robot
+Resource  resource_create_survey.robot
 Suite Setup  Open And Configure Browser
 Suite Teardown  Close Browser
 Test Setup  Go To Home Page
@@ -74,3 +75,8 @@ Survey Result With Cutoff Value One Can not Be Deleted
     Expand Result Card  1
     Page Should Not Contain  Delete
 
+New Survey Has Survey Result For Cutoff Value 1.0
+    Click Link  New survey
+    Make A Survey
+    Page Should Contain  100.0% of max points returns user:
+    Page Should Contain  Your skills in this topic are excellent!

--- a/src/tests/services/survey_service_test.py
+++ b/src/tests/services/survey_service_test.py
@@ -34,6 +34,12 @@ class TestSurveyService(unittest.TestCase):
         self.assertEqual(check, 1)
         self.repo_mock.create_survey.assert_called_with(
             name, title, description)
+        self.repo_mock.create_survey_result.assert_called_with(
+            1,
+            "Your skills in this topic are excellent!",
+            1.0
+        )
+        
 
     def test_create_survey_with_no_name_does_not_work(self):
         name = ""
@@ -175,6 +181,11 @@ class TestSurveyService(unittest.TestCase):
         self.assertEqual(check, 1)
         self.repo_mock.create_category.assert_called_with(
             survey_id, name, description, content_links)
+        self.repo_mock.create_category_result.called_with(
+            1,
+            "Your skills in this topic are excellent!",
+            1.0
+        )
 
     def test_add_admin_calls_repo_correctly(self):
         self.repo_mock.add_admin.return_value = 1


### PR DESCRIPTION
- Create a new survey result with cutoff 1 whenever creating a new survey
- Fixed the tests for creating surveys or categories to check that result creation method is called
- Closes #387 