### PR TITLE
Dev rami

### DIFF
--- a/src/repositories/survey_repository.py
+++ b/src/repositories/survey_repository.py
@@ -1208,6 +1208,32 @@ class SurveyRepository:
             return category_result_id[0]
         return None
 
+    def update_category_and_survey_updated_at(self, category_id, survey_id):
+        """
+        Updates the updated_at fields of a given category and survey
+        """
+        sql1 = """
+        UPDATE "Categories"
+        SET
+            "updatedAt"=NOW()
+        WHERE id=:category_id
+        """
+        values1 = {
+            "category_id": category_id}
+
+        sql2 = """
+        UPDATE "Surveys"
+        SET
+            "updatedAt"=NOW()
+        WHERE id=:survey_id
+        """
+        values2 = {
+            "survey_id": survey_id}
+
+        db.session.execute(sql1, values1)
+        db.session.execute(sql2, values2)
+        db.session.commit()        
+    
     def get_category_results_from_category_id(self, category_id):
         """
         Selects id, text and cutoff from all category_results linked to a given category_id

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -384,6 +384,7 @@ class SurveyService:
             cutoff_from_maxpts = 1.0
             self.create_category_result(
                 category_id,
+                survey_id,
                 category_result_text,
                 cutoff_from_maxpts
             )
@@ -463,9 +464,10 @@ class SurveyService:
         """
         return self.survey_repository.delete_category(category_id)
     
-    def delete_category_results_for_category(self, category_id):
+    def delete_category_results_for_category(self, category_id, survey_id):
         """ Deletes all category results for the given
         category from the repository """
+        self.update_category_and_survey_updated_at(category_id, survey_id)
         return self.survey_repository.delete_category_results_of_category(category_id)
 
     def get_number_of_submissions_for_survey(self, survey_id):
@@ -577,10 +579,18 @@ class SurveyService:
 
         return result
 
-    def create_category_result(self, category_id: int, text: str, cutoff_from_maxpts: float):
+    
+    def update_category_and_survey_updated_at(self, category_id, survey_id):
+        """ Updates the updatedAt of a category and survey based on category_id
+        """
+        self.survey_repository.update_category_and_survey_updated_at(category_id, survey_id)
+
+    
+    def create_category_result(self, category_id: int, survey_id: int, text: str, cutoff_from_maxpts: float):
         """Create a new category result
 
         Returns id of category result"""
+        self.update_category_and_survey_updated_at(category_id, survey_id)
         return self.survey_repository.create_category_result(category_id, text, cutoff_from_maxpts)
 
     def get_category_results_from_category_id(self, category_id):
@@ -610,14 +620,15 @@ class SurveyService:
         """Updates the original results of a survey to new ones"""
         return self.survey_repository.update_survey_results(original_results, new_results, survey_id)
 
-    def delete_category_result(self, category_result_id):
+    def delete_category_result(self, category_result_id, category_id, survey_id):
         """ Deletes the category result given as parameter
         """
-
+        self.update_category_and_survey_updated_at(category_id, survey_id)
         return self.survey_repository.delete_category_result(category_result_id)
 
-    def update_category_results(self, original_results, new_results,survey_id):
+    def update_category_results(self, original_results, new_results, survey_id, category_id):
         """Updates the original results of a survey to new ones"""
+        self.update_category_and_survey_updated_at(category_id, survey_id)
         return self.survey_repository.update_category_results(original_results, new_results, survey_id)
 
     def check_survey_status(self, survey_id):

--- a/src/templates/components/sections/category_results.html
+++ b/src/templates/components/sections/category_results.html
@@ -8,9 +8,12 @@
 </div>
 {% if show_results %}
 {% for result in show_results %}
-    <p>{{ result[0]}}
-    <br>{{ result[1] }}</p>
-    <br>
+    <p>{{ result[0]}} <span style="color:grey">of the max points returns the following result to the user:</span></p>
+    <p>"{{ result[1] }}"</p>
+    <hr style="margin-bottom:10px; margin-top:10px">
+    <!-- <p>AA: {{ result[0]}}
+    <br>BB: {{ result[1] }}</p>
+    <br> -->
 {% endfor %}
 {% else %}
     <p>Survey has no results 🥺</p>

--- a/src/templates/surveys/edit_category.html
+++ b/src/templates/surveys/edit_category.html
@@ -85,9 +85,7 @@
     {% endcall %}
     {% endif %}
     </form>
-    {% if category_results %}
-        {% include "components/sections/category_results.html" %}
-    {% endif %}
+    {% include "components/sections/category_results.html" %}
     </div>
 </div>
 

--- a/src/tests/robot_tests/category_results.robot
+++ b/src/tests/robot_tests/category_results.robot
@@ -15,7 +15,7 @@ Logged In User Can View Category Results
     Login With Correct Credentials
     Go To Survey  1
     Click Link  edit_button_1
-    Page Should Contain  0%-40% of max points returns user
+    Page Should Contain  0% - 40% of the max points
     Page Should Contain  Dynamically fetched feedback text for category score.
     Click Element  categoryresults
     Page Should Contain   Category results for Category 1

--- a/src/tests/services/survey_service_test.py
+++ b/src/tests/services/survey_service_test.py
@@ -177,6 +177,7 @@ class TestSurveyService(unittest.TestCase):
     def test_create_category_calls_repo_correctly(self):
         self.repo_mock.create_category.return_value = 1
         survey_id = "1"
+        category_id="1"
         name = "name"
         description = "description"
         content_links = [{"url": "https://www.eficode.com/cases/hansen", "type": "Case Study"},
@@ -187,6 +188,7 @@ class TestSurveyService(unittest.TestCase):
         self.repo_mock.create_category.assert_called_with(
             survey_id, name, description, content_links)
         self.repo_mock.create_category_result.called_with(
+            1,
             1,
             "Your skills in this topic are excellent!",
             1.0
@@ -453,10 +455,12 @@ class TestSurveyService(unittest.TestCase):
     def test_create_category_result_calls_repo_correctly(self):
         self.repo_mock.create_category_result.return_value = 1
         category_id = 1
+        survey_id = 1
         text = "Dynamically fetched category result text"
         cutoff_from_maxpts = 1.0
         response = self.survey_service.create_category_result(
             category_id,
+            survey_id,
             text,
             cutoff_from_maxpts)
         self.assertEqual(response, category_id)
@@ -499,7 +503,7 @@ class TestSurveyService(unittest.TestCase):
 
     def test_delete_category_result_calls_repo_correctly(self):
         self.repo_mock.delete_category_result.return_value = True
-        response = self.survey_service.delete_category_result(1)
+        response = self.survey_service.delete_category_result(1,1,1)
         self.assertTrue(response)
         self.repo_mock.delete_category_result.assert_called_with(1)
 
@@ -508,7 +512,7 @@ class TestSurveyService(unittest.TestCase):
         original_results = [[5, "Bad", 0.3], [6, "Good", 1.0]]
         new_results = [[5, "Decent", 0.3], [6, "Great", 1.0]]
         response = self.survey_service.update_category_results(original_results,
-                                                             new_results, 3)
+                                                             new_results, 3, 1)
         self.assertTrue(response)
         self.repo_mock.update_category_results.assert_called_with(original_results,
                                                                 new_results, 3)
@@ -546,6 +550,6 @@ class TestSurveyService(unittest.TestCase):
     
     def test_delete_category_results_for_category_calls_repo_correctly(self):
         self.repo_mock.delete_category_results_of_category.return_value = True
-        result = self.survey_service.delete_category_results_for_category(1)
+        result = self.survey_service.delete_category_results_for_category(1,1)
         self.assertTrue(result)
         self.repo_mock.delete_category_results_of_category.assert_called_with(1)

--- a/src/views/surveys.py
+++ b/src/views/surveys.py
@@ -414,9 +414,9 @@ def add_category_result(survey_id, category_id):
             return redirect(f"/edit_category/{survey_id}/{category_id}/new-category-result")
         if original_results != new_results:
             survey_service.update_category_results(
-                original_results, new_results, survey_id)
+                original_results, new_results, survey_id, category_id)
     if new_cat_result_text and new_cat_cutoff:
-        survey_service.create_category_result(category_id, new_cat_result_text, new_cat_cutoff)
+        survey_service.create_category_result(category_id, survey_id, new_cat_result_text, new_cat_cutoff)
     return redirect(f"/edit_category/{survey_id}/{category_id}/new-category-result")
 
 
@@ -491,7 +491,7 @@ def delete_category():
 
     return_value = survey_service.delete_category(category_id)
     if return_value is True:
-        survey_service.delete_category_results_for_category(category_id)
+        survey_service.delete_category_results_for_category(category_id, survey_id)
         flash("Successfully deleted category", "confirmation")
         return redirect(f"/surveys/{survey_id}")
 
@@ -505,7 +505,7 @@ def delete_category_result(category_result_id):
     """
     survey_id = request.form["survey_id"]
     category_id = request.form["category_id"]
-    survey_service.delete_category_result(category_result_id)
+    survey_service.delete_category_result(category_result_id, category_id, survey_id)
     return redirect(f"/edit_category/{survey_id}/{category_id}/new-category-result")
 
 

--- a/src/views/surveys.py
+++ b/src/views/surveys.py
@@ -331,12 +331,12 @@ def edit_category_page(survey_id, category_id):
         for i in range(len(category_results)):
             if i == 0:
                 if float(category_results[0][2]) == 0.0:
-                    text = "0% of max points returns user"
+                    text = "0 %"
                 else:
-                    text = f"0%-{int(category_results[0][2]*100)}% of max points returns user"
+                    text = f"0% - {int(category_results[0][2]*100)}%"
                 show_results.append([text, category_results[0][1]])
             else:
-                text = f"{int(category_results[i-1][2]*100)}%-{int(category_results[i][2]*100)}% of max points returns user"
+                text = f"{int(category_results[i-1][2]*100)}% - {int(category_results[i][2]*100)}%"
                 show_results.append([text, category_results[i][1]])
     return render_template("surveys/edit_category.html",
                            ENV=app.config["ENV"],
@@ -428,7 +428,7 @@ def new_category_result_view(survey_id, category_id):
     results = survey_service.get_category_results_from_category_id(category_id)
     if results:
         return render_template("surveys/edit_category_results.html", survey=survey, category = category, results=results,  ENV=app.config["ENV"])
-    return render_template("surveys/edit_category_results.html", survey=survey_id, first=True, results=[],  ENV=app.config["ENV"]   )
+    return render_template("surveys/edit_category_results.html", survey=survey, category = category, first=True, results=[],  ENV=app.config["ENV"]   )
 
 
 @surveys.route("/add_content_link", methods=["POST"])


### PR DESCRIPTION
Changes:
- UpdatedAt not updated when deleting or editing/creating category results. Clarification: Purpose is to escalate updatedAt updates upwards as long as possible in the chain. So when a category result is updated, it should update the udpatedAt of the category and of the survey.
- Align category result styling & text to be similar as survey result styling
- If a category has been created but for some reason but there are no results for it, show the link for managing results so one can be created

closes #429 