### PR TITLE
Filter statistics by user group id instead of user group name

### DIFF
--- a/src/repositories/survey_repository.py
+++ b/src/repositories/survey_repository.py
@@ -821,26 +821,7 @@ class SurveyRepository:
         except exc.SQLAlchemyError as exception:
             return exception
 
-    def get_answer_distribution_filtered(self, survey_id,
-                                         start_date: datetime = None,
-                                         end_date: datetime = None,
-                                         group_name: str = "",
-                                         email: str = ""):
-        """ Finds and returns the distribution of user answers
-        over the answer options of a survey.
-
-        Filtering by date range and/or user group and/or email. Start and end
-        dates are included in the query.
-
-        Returns a table where each row contains:
-        question id, question text, answer id, answer text, user answer counts
-        """
-
-        group_id = self._find_user_group_by_name(group_name)
-
-        return self.get_answer_distribution(survey_id, start_date, end_date, group_id, email)
-
-    def _find_user_group_by_name(self, group_name):
+    def find_user_group_by_name(self, group_name):
         """Finds and returns user group id by user group name
         """
         sql = """SELECT id, group_name FROM "Survey_user_groups" WHERE lower(group_name)=:group_name"""
@@ -1060,7 +1041,7 @@ class SurveyRepository:
         related_questions = self.get_questions_of_survey(survey_id)
 
         if user_group_name:
-            user_group_id = self._find_user_group_by_name(user_group_name)
+            user_group_id = self.find_user_group_by_name(user_group_name)
         else:
             user_group_id = None
 

--- a/src/repositories/survey_repository.py
+++ b/src/repositories/survey_repository.py
@@ -506,7 +506,7 @@ class SurveyRepository:
                                       survey_id: int,
                                       start_date: datetime = None,
                                       end_date: datetime = None,
-                                      group_name=None,
+                                      group_id=None,
                                       email=""):
         """ Returns a list of users who have answered a given survey.
         Results can be filtered by a timerange, group name and email address.
@@ -514,7 +514,7 @@ class SurveyRepository:
             survey_id: Id of the survey
             start_time: Start of timerange to filter by (optional)
             end_time: End of timerange to filter by (optional)
-            group_name: User group to filter by (optional)
+            group_id: User group to filter by (optional)
                         If the group is None, all users all listed. If the
                         group is string "None", only users without any group
                         are listed.
@@ -547,15 +547,14 @@ class SurveyRepository:
             ON u."groupId" = sua.id
         WHERE s.id=:survey_id
             AND ((:start_date IS NULL AND :end_date IS NULL) OR (ua."updatedAt" > :start_date AND ua."updatedAt" < :end_date))
-            AND ((:group_name IS NULL) OR
-                 ((:group_name = 'None') AND (sua.group_name IS NULL)) OR
-                 (group_name=:group_name))
+            AND ((:group_id IS NULL) OR
+                 (sua.id=:group_id))
             AND COALESCE (email, '') like :email
         """
         values = {"survey_id": survey_id,
                   "start_date": start_date,
                   "end_date": end_date,
-                  "group_name": group_name,
+                  "group_id": group_id,
                   "email": f"%{email}%"}
 
         try:

--- a/src/repositories/survey_repository.py
+++ b/src/repositories/survey_repository.py
@@ -1008,7 +1008,7 @@ class SurveyRepository:
 
     def calculate_average_scores_by_category(self,
                                              survey_id,
-                                             user_group_name=None,
+                                             user_group_id=None,
                                              start_date=None,
                                              end_date=None,
                                              email=""):
@@ -1040,11 +1040,6 @@ class SurveyRepository:
         # currently group id None lists all users
         question_averages = []
         related_questions = self.get_questions_of_survey(survey_id)
-
-        if user_group_name:
-            user_group_id = self.find_user_group_by_name(user_group_name)
-        else:
-            user_group_id = None
 
         for question in related_questions:
 

--- a/src/repositories/survey_repository.py
+++ b/src/repositories/survey_repository.py
@@ -522,7 +522,7 @@ class SurveyRepository:
 
         Returns:
             On succeed: A list of lists where each element contains
-                [id, email, group_name, answer_time]
+                [id, email, group_id, group_name, answer_time]
             On error / no users who answered found:
                 None
         """
@@ -530,6 +530,7 @@ class SurveyRepository:
         SELECT
             DISTINCT u.id,
             u.email,
+            sua.id as group_id,
             sua.group_name,
             ua."updatedAt" as answer_time
         FROM

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -298,7 +298,7 @@ class SurveyService:
                                                survey_id: int,
                                                start_date: datetime,
                                                end_date: datetime,
-                                               group_name,
+                                               group_id,
                                                email):
         """ Returns a list of users who have answered a given survey in a given timerange,
         belonging the given group and having a matching email address
@@ -311,7 +311,7 @@ class SurveyService:
 
         Returns:
            On succeed: A list of lists where each element contains
-               [id, email, group_name, answer_time]
+               [id, email, group_id, group_name, answer_time]
            On error / no users who answered found:
                None
         """
@@ -319,14 +319,10 @@ class SurveyService:
         if start_date > end_date or end_date < start_date:
             return None
 
-        # Changes an empty string ("") value to None
-        if not group_name:
-            group_name = None
-
         return self.survey_repository.get_users_who_answered_survey(survey_id,
                                                                     start_date,
                                                                     end_date,
-                                                                    group_name,
+                                                                    group_id,
                                                                     email)
 
     def get_users_who_answered_survey_in_timerange(self, survey_id: int, start_date: datetime, end_date: datetime):

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -288,7 +288,7 @@ class SurveyService:
 
         Returns:
             On succeed: A list of lists where each element contains
-                [id, email, group_name, answer_time]
+                [id, email, group_id, group_name, answer_time]
             On error / no users who answered found:
                 None
         """

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -523,7 +523,7 @@ class SurveyService:
 
     def calculate_average_scores_by_category(self,
                                              survey_id,
-                                             user_group_name=None,
+                                             user_group_id=None,
                                              start_date=None,
                                              end_date=None,
                                              email=""):
@@ -562,7 +562,7 @@ class SurveyService:
         all_averages = self.survey_repository.calculate_average_scores_by_category(
             survey_id)
         filtered_averages = self.survey_repository.calculate_average_scores_by_category(
-            survey_id, user_group_name, start_date, end_date, email)
+            survey_id, user_group_id, start_date, end_date, email)
 
         result = []
 

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -499,12 +499,13 @@ class SurveyService:
         Returns a table with question id and text, answer
         id and text, number of user answers
         """
+        group_id = self.survey_repository.find_user_group_by_name(group_name)
 
-        result = self.survey_repository.get_answer_distribution_filtered(survey_id,
-                                                                         start_date,
-                                                                         end_date,
-                                                                         group_name,
-                                                                         email)
+        result = self.survey_repository.get_answer_distribution(survey_id,
+                                                                start_date,
+                                                                end_date,
+                                                                group_id,
+                                                                email)
 
         return result
 

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -483,7 +483,7 @@ class SurveyService:
                                                      survey_id,
                                                      start_date: datetime = None,
                                                      end_date: datetime = None,
-                                                     group_name: str = "",
+                                                     group_id=None,
                                                      email: str = ""):
         """
         Fetches the distribution of user answers over the
@@ -493,13 +493,12 @@ class SurveyService:
             survey_id   The id of the survey
             start_date  Filter out answers before this date (optional)
             end_date    Filter out answers after this date (optional)
-            group_name  Filter out answers from user, who doen't belong to this group (optional)
-            email       Filter in answers from user, who's email matches (optional)
+            group_id    Filter out answers from users not in this group (optional)
+            email       Filter in answers from users whose email matches (optional)
 
         Returns a table with question id and text, answer
         id and text, number of user answers
         """
-        group_id = self.survey_repository.find_user_group_by_name(group_name)
 
         result = self.survey_repository.get_answer_distribution(survey_id,
                                                                 start_date,

--- a/src/templates/surveys/statistics.html
+++ b/src/templates/surveys/statistics.html
@@ -42,9 +42,9 @@
                 <select name="filter_group_id" id="filter_group_id"
                     class="bg-white border border-slate-300 text-gray-900 text-sm rounded-lg focus:invalid:border-rose-500 focus:ring-sky-500 focus:border-sky-500 block w-full p-2 appearance-none">
                     {% for key, value in group_names.items() %}
-                    {% if value == filter_group_id %}
+                    {% if key == filter_group_id %}
                     <option value="{{ key }}" id="{{ key }}" selected>{{ value }}</option>
-                    {% elif value != None %}
+                    {% elif key != None %}
                     <!-- value == None could be used to filter-in only users, which doesn't
                        have any group. This is not yet implemented in all repositories, however
                     -->
@@ -64,7 +64,7 @@
     </form>
     {% endcall %}
 
-    <!-- CAETGORY SCORES -->
+    <!-- CATEGORY SCORES -->
     <div class="flex flex-row items-center justify-start gap-4">
         <h2>Category scores in answers</h2>
         <div class="flex-grow border-t border-slate-200"></div>

--- a/src/templates/surveys/statistics.html
+++ b/src/templates/surveys/statistics.html
@@ -38,17 +38,17 @@
                 {{ form_elements.text_input("filter_email", "", "", false, filter_email) }}
             </div>
             <div class="flex flex-col gap-2 w-full">
-                {{ form_elements.label("filter_group_name", "User group") }}
-                <select name="filter_group_name" id="filter_group_name"
+                {{ form_elements.label("filter_group_id", "User group") }}
+                <select name="filter_group_id" id="filter_group_id"
                     class="bg-white border border-slate-300 text-gray-900 text-sm rounded-lg focus:invalid:border-rose-500 focus:ring-sky-500 focus:border-sky-500 block w-full p-2 appearance-none">
                     {% for key, value in group_names.items() %}
-                    {% if value == filter_group_name %}
-                    <option value="{{ value }}" id="{{ key }}" selected>{{ key }}</option>
+                    {% if value == filter_group_id %}
+                    <option value="{{ key }}" id="{{ key }}" selected>{{ value }}</option>
                     {% elif value != None %}
                     <!-- value == None could be used to filter-in only users, which doesn't
                        have any group. This is not yet implemented in all repositories, however
                     -->
-                    <option value="{{ value }}" id="{{ key }}">{{ key }}</option>
+                    <option value="{{ key }}" id="{{ key }}">{{ value }}</option>
                     {% endif %}
                     {% endfor %}
                 </select>

--- a/src/tests/repositories/survey_repository_test.py
+++ b/src/tests/repositories/survey_repository_test.py
@@ -806,7 +806,7 @@ class TestSurveyRepository(unittest.TestCase):
             users_non_filtered = self.repo.get_users_who_answered_survey(
                 survey_id)
             users_filtered = self.repo.get_users_who_answered_survey(
-                survey_id, group_name="Presidentes")
+                survey_id, group_id=survey_user_group_id_1)
 
         self.assertEqual(len(users_non_filtered), 2)
         self.assertEqual(len(users_filtered), 1)
@@ -925,7 +925,7 @@ class TestSurveyRepository(unittest.TestCase):
             averages = self.repo.calculate_average_scores_by_category(
                 survey_id)
             averages_filter_group_1 = self.repo.calculate_average_scores_by_category(
-                survey_id, user_group_1_name)
+                survey_id, user_group_1_id)
             averages_filter_date_old = self.repo.calculate_average_scores_by_category(
                 survey_id, start_date=start_date_old, end_date=end_date_old)
             averages_filter_date_current = self.repo.calculate_average_scores_by_category(

--- a/src/tests/repositories/survey_repository_test.py
+++ b/src/tests/repositories/survey_repository_test.py
@@ -629,7 +629,7 @@ class TestSurveyRepository(unittest.TestCase):
     def test_answer_distribution_filtered_by_email(self):
         with self.app.app_context():
             survey_id = self.repo.survey_exists("Elephants")[1]
-            result = self.repo.get_answer_distribution_filtered(
+            result = self.repo.get_answer_distribution(
                 survey_id, email="@")
 
         self.assertEqual(result[0][4], 3)
@@ -638,7 +638,7 @@ class TestSurveyRepository(unittest.TestCase):
     def test_answer_distribution_per_user_group(self):
         with self.app.app_context():
             survey_id = self.repo.survey_exists("Elephants")[1]
-            group_id = self.repo._find_user_group_by_name("Supertestaajat")
+            group_id = self.repo.find_user_group_by_name("Supertestaajat")
             result = self.repo.get_answer_distribution(
                 survey_id, user_group_id=group_id)
 

--- a/src/tests/robot_tests/statistics.robot
+++ b/src/tests/robot_tests/statistics.robot
@@ -36,7 +36,8 @@ Statistics Page Shows Answer Distribution Charts
 
 Statistics Page Shows Filtered Charts After Applying Filter
     Go To Statistics  8
-    Select From List By Value  name:filter_group_name  B-ryhmä
+    # Choose user group B-ryhmä
+    Select From List By Value  name:filter_group_id  bb2ce58d-f27b-4ade-9e31-e8aca8c7ca20
     Click Button  Filter
     Element Should Be Visible  chart_23_filtered
     Element Should Be Visible  chart_24_filtered
@@ -55,7 +56,8 @@ Toggle Filter For Charts Works When Only Time Filter Applied
 
 Statistics Page Shows Unfiltered Charts After Toggling Filter First Time
     Go To Statistics  8
-    Select From List By Value  name:filter_group_name  B-ryhmä
+    # Choose user group B-ryhmä
+    Select From List By Value  name:filter_group_id  bb2ce58d-f27b-4ade-9e31-e8aca8c7ca20
     Click Button  Filter
     Click Button  toggle_filter_chart_23
     Click Button  toggle_filter_chart_24
@@ -66,7 +68,8 @@ Statistics Page Shows Unfiltered Charts After Toggling Filter First Time
 
 Statistics Page Shows Filtered Charts After Toggling Filter Second Time
     Go To Statistics  8
-    Select From List By Value  name:filter_group_name  B-ryhmä
+    # Choose user group B-ryhmä
+    Select From List By Value  name:filter_group_id  bb2ce58d-f27b-4ade-9e31-e8aca8c7ca20
     Click Button  Filter
     Click Button  toggle_filter_chart_23
     Click Button  toggle_filter_chart_23
@@ -90,7 +93,8 @@ Entering Invalid Date to User Filter Does Not Filter Anything
 
 Filtering By Group Name Filters Users
     Go To Statistics  8
-    Select From List By Value  name:filter_group_name  Supertestaajat
+    # Choose user group Supertestaajat
+    Select From List By Value  name:filter_group_id  737cdf09-cc6f-47de-adcd-e7aaab0adc39
     Click Button  Filter
     Page Should Contain  Users with submissions (1 / 5)
 
@@ -111,7 +115,8 @@ Filtering By Email Filters Users
 
 With Filtering Unfiltered Average Is Shown
     Go To Statistics  8
-    Select From List By Value  name:filter_group_name  B-ryhmä
+    # Choose user group B-ryhmä
+    Select From List By Value  name:filter_group_id  bb2ce58d-f27b-4ade-9e31-e8aca8c7ca20
     Click Button  Filter
     Page Should Contain  Average score
     Page Should Contain  5.0   
@@ -120,7 +125,8 @@ With Filtering Unfiltered Average Is Shown
 
 Filtering With Email And Group Shows Correct Averages
     Go To Statistics  8
-    Select From List By Value  name:filter_group_name  B-ryhmä
+    # Choose user group B-ryhmä
+    Select From List By Value  name:filter_group_id  bb2ce58d-f27b-4ade-9e31-e8aca8c7ca20
     Input Text  filter_email  duser
     Click Button  Filter    
     Page Should Contain  5.0

--- a/src/tests/services/survey_service_test.py
+++ b/src/tests/services/survey_service_test.py
@@ -308,12 +308,13 @@ class TestSurveyService(unittest.TestCase):
         )
 
     def test_get_answer_distribution_for_survey_questions_calls_repo_correctly(self):
-        self.repo_mock.get_answer_distribution.return_value = "None"
+        self.repo_mock.get_answer_distribution.return_value = None
+        self.repo_mock.find_user_group_by_name.return_value = "asadflkj"
         survey_id = 1
         self.survey_service.get_answer_distribution_for_survey_questions(
             survey_id)
-        self.repo_mock.get_answer_distribution_filtered.assert_called_with(
-            survey_id, None, None, '', '')
+        self.repo_mock.get_answer_distribution.assert_called_with(
+            survey_id, None, None, 'asadflkj', '')
 
     def test_get_users_who_answered_survey_in_timerange_returns_none_with_invalid_timerage(self):
         start_date_1 = datetime.fromisoformat("2011-11-04 00:05:23.283")

--- a/src/tests/services/survey_service_test.py
+++ b/src/tests/services/survey_service_test.py
@@ -309,12 +309,11 @@ class TestSurveyService(unittest.TestCase):
 
     def test_get_answer_distribution_for_survey_questions_calls_repo_correctly(self):
         self.repo_mock.get_answer_distribution.return_value = None
-        self.repo_mock.find_user_group_by_name.return_value = "asadflkj"
         survey_id = 1
         self.survey_service.get_answer_distribution_for_survey_questions(
             survey_id)
         self.repo_mock.get_answer_distribution.assert_called_with(
-            survey_id, None, None, 'asadflkj', '')
+            survey_id, None, None, None, '')
 
     def test_get_users_who_answered_survey_in_timerange_returns_none_with_invalid_timerage(self):
         start_date_1 = datetime.fromisoformat("2011-11-04 00:05:23.283")
@@ -385,7 +384,7 @@ class TestSurveyService(unittest.TestCase):
 
         self.repo_mock.get_users_who_answered_survey.assert_not_called()
 
-    def test_get_users_who_answered_survey_filtered_works_with_empty_string_as_group(self):
+    def test_get_users_who_answered_survey_filtered_works_with_no_group(self):
         survey_id = 1
         start_date = datetime.fromisoformat("2020-11-04 00:05:23.283")
         end_date = datetime.fromisoformat("2021-11-04 00:05:23.283")
@@ -395,7 +394,7 @@ class TestSurveyService(unittest.TestCase):
         self.repo_mock.get_users_who_answered_survey.return_value = repo_value_to_return
 
         survey_reponse = self.survey_service.get_users_who_answered_survey_filtered(
-            survey_id, start_date, end_date, "", "")
+            survey_id, start_date, end_date, None, "")
 
         self.repo_mock.get_users_who_answered_survey.assert_called_once_with(
             survey_id, start_date, end_date, None, "")

--- a/src/views/statistics.py
+++ b/src/views/statistics.py
@@ -25,9 +25,9 @@ def statistics(survey_id):
     users = users if users else []
     total_users = len(users)
 
-    group_names = {"All user groups": ""}
+    group_names = {"All": "All user groups"}
     for user in users:
-        group_names[user.group_name] = user.group_name
+        group_names[user.group_id] = user.group_name
 
     answer_distribution = helper.save_question_answer_charts(
         survey_service.get_answer_distribution_for_survey_questions(survey_id)

--- a/src/views/statistics.py
+++ b/src/views/statistics.py
@@ -73,13 +73,14 @@ def filtered_statistics(survey_id):
 
     survey = survey_service.get_survey(survey_id)
 
-    filter_group_id_str = request.form["filter_group_id"]
+    filter_group_id = request.form["filter_group_id"]
     filter_email = request.form["filter_email"]
 
-    if filter_group_id_str == "All":
+    if filter_group_id == "All":
         filter_group_id = None
     else:
-        filter_group_id = uuid.UUID(filter_group_id_str)
+        filter_group_id = uuid.UUID(filter_group_id)
+
     # submissions = survey_service.get_number_of_submissions_for_survey(
     #     survey_id)
 
@@ -121,6 +122,9 @@ def filtered_statistics(survey_id):
     filter_start_date = filter_start_date.strftime(HTML_DATE_INPUT_TIMEFORMAT)
     filter_end_date = filter_end_date.strftime(HTML_DATE_INPUT_TIMEFORMAT)
 
+    if not filter_group_id:
+        filter_group_id = "All"
+
     return render_template("surveys/statistics.html",
                            ENV=app.config["ENV"],
                            survey=survey,
@@ -131,7 +135,7 @@ def filtered_statistics(survey_id):
                            categories=categories,
                            filter_start_date=filter_start_date,
                            filter_end_date=filter_end_date,
-                           filter_group_id=filter_group_id_str,
+                           filter_group_id=filter_group_id,
                            filter_group_name=filter_group_name,
                            filter_email=filter_email,
                            group_names=group_names,

--- a/src/views/statistics.py
+++ b/src/views/statistics.py
@@ -73,9 +73,13 @@ def filtered_statistics(survey_id):
 
     survey = survey_service.get_survey(survey_id)
 
-    filter_group_id = uuid.UUID(request.form["filter_group_id"])
+    filter_group_id_str = request.form["filter_group_id"]
     filter_email = request.form["filter_email"]
 
+    if filter_group_id_str == "All":
+        filter_group_id = None
+    else:
+        filter_group_id = uuid.UUID(filter_group_id_str)
     # submissions = survey_service.get_number_of_submissions_for_survey(
     #     survey_id)
 
@@ -127,7 +131,8 @@ def filtered_statistics(survey_id):
                            categories=categories,
                            filter_start_date=filter_start_date,
                            filter_end_date=filter_end_date,
-                           filter_group_id=filter_group_id,
+                           filter_group_id=filter_group_id_str,
+                           filter_group_name=filter_group_name,
                            filter_email=filter_email,
                            group_names=group_names,
                            show_userlist=True,

--- a/src/views/statistics.py
+++ b/src/views/statistics.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 from flask import render_template, redirect, request, Blueprint, flash, abort
 from flask import current_app as app
@@ -36,7 +37,6 @@ def statistics(survey_id):
     filter_start_date = (datetime.datetime.now() -
                          datetime.timedelta(days=10*365)).strftime(HTML_DATE_INPUT_TIMEFORMAT)
     filter_end_date = datetime.datetime.now().strftime(HTML_DATE_INPUT_TIMEFORMAT)
-    filter_group_name = ""
     filter_email = ""
 
     return render_template("surveys/statistics.html",
@@ -50,7 +50,7 @@ def statistics(survey_id):
                            answer_distribution=answer_distribution,
                            filter_start_date=filter_start_date,
                            filter_end_date=filter_end_date,
-                           filter_group_name=filter_group_name,
+                           filter_group_id="",
                            filter_email=filter_email,
                            group_names=group_names,
                            show_userlist=False,
@@ -73,17 +73,27 @@ def filtered_statistics(survey_id):
 
     survey = survey_service.get_survey(survey_id)
 
-    filter_group_name = request.form["filter_group_name"]
+    filter_group_id = uuid.UUID(request.form["filter_group_id"])
     filter_email = request.form["filter_email"]
 
     # submissions = survey_service.get_number_of_submissions_for_survey(
     #     survey_id)
 
+    users = survey_service.get_users_who_answered_survey(survey_id)
+    users = users if users else []
+    total_users = len(users)
+
+    group_names = {"All": "All user groups"}
+    for user in users:
+        group_names[user.group_id] = user.group_name
+
+    filter_group_name = group_names[filter_group_id]
+
     answer_distribution = helper.save_question_answer_charts(
         survey_service.get_answer_distribution_for_survey_questions(survey_id,
                                                                     filter_start_date,
                                                                     filter_end_date,
-                                                                    filter_group_name,
+                                                                    filter_group_id,
                                                                     filter_email),
         filter_group_name,
         filter_start_date,
@@ -91,23 +101,15 @@ def filtered_statistics(survey_id):
     )
 
     categories = survey_service.calculate_average_scores_by_category(survey_id,
-                                                                     filter_group_name,
+                                                                     filter_group_id,
                                                                      filter_start_date,
                                                                      filter_end_date,
                                                                      filter_email)
 
-    users = survey_service.get_users_who_answered_survey(survey_id)
-    users = users if users else []
-    total_users = len(users)
-
-    group_names = {"All user groups": ""}
-    for user in users:
-        group_names[user.group_name] = user.group_name
-
     users = survey_service.get_users_who_answered_survey_filtered(survey_id,
                                                                   filter_start_date,
                                                                   filter_end_date,
-                                                                  filter_group_name,
+                                                                  filter_group_id,
                                                                   filter_email)
 
     users = users if users else []
@@ -125,7 +127,7 @@ def filtered_statistics(survey_id):
                            categories=categories,
                            filter_start_date=filter_start_date,
                            filter_end_date=filter_end_date,
-                           filter_group_name=filter_group_name,
+                           filter_group_id=filter_group_id,
                            filter_email=filter_email,
                            group_names=group_names,
                            show_userlist=True,


### PR DESCRIPTION
App now uses user group id in stats filtering; refactored the backend stats functions accordingly. 

Prevents stats becoming distorted by possible duplicate user group names 