### PR TITLE
Navigation bar was missing closing </strong>

### DIFF
--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -73,7 +73,7 @@
                         {% if url_for(request.endpoint, **request.view_args) == '/logs' %}
 
                         <a href="/logs"
-                            class="text-sky-900 hover:text-sky-700 hover:underline font-medium rounded-lg text-sm"><strong>Logs</strong</a>
+                            class="text-sky-900 hover:text-sky-700 hover:underline font-medium rounded-lg text-sm"><strong>Logs</strong></a>
 
                         {% else %}
 

--- a/src/templates/logs/logs.html
+++ b/src/templates/logs/logs.html
@@ -1,6 +1,5 @@
 {% extends "layout.html" %}
 {% import "components/macros/buttons.html" as buttons %}
-
 {% block content %}
 
 <h2>Event log</h2>


### PR DESCRIPTION
Navigation bar was missing closing `</strong>`. This made the whole Logs page bold.
Is now fixed 🤝